### PR TITLE
Updated to allow for setting of paths can be extended for other programatic settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ body
   height: sidelength
 ```
 
+#####Adding paths for @require
+Add your stylify config to your application package.json
+add a paths array to your mixins folder etc. Paths can be specified in glob notation.
+
+```json
+"stylify": {
+    "paths": [
+      "application/stylus/**/"
+    ]
+  }
+```
+
 ## License(s)
 
 ### MIT

--- a/index.js
+++ b/index.js
@@ -25,9 +25,32 @@
 var stylus = require('stylus');
 var cleanCss = require('clean-css');
 var through = require('through');
+var glob = require('glob');
+var _ = require('lodash');
+
+var appPackage = require(process.cwd() + '/package.json');
+
+
+var paths = null;
+
+if(!!appPackage.stylify && appPackage.stylify.paths instanceof Array){
+  paths = _.chain(
+    appPackage.stylify.paths.map(function(path){
+      return glob.sync(path);
+    })
+  )
+  .flatten()
+  .uniq()
+  .value();
+}
 
 function compile(file, data) {
-  var compiled = stylus(data, { filename: file }).render();
+
+  var style = stylus(data, { filename: file });
+  if(!!paths) { 
+    style.set('paths', paths); 
+  }
+  var compiled = style.render();
   var minified = (new cleanCss).minify(compiled);
 
   return 'module.exports = ' + JSON.stringify(minified) + ';';

--- a/package.json
+++ b/package.json
@@ -1,12 +1,17 @@
 {
   "name": "stylify",
   "description": "browserify plugin for stylus",
-  "author": "Damon Oehlman <damon.oehlman@gmail.com>",
+  "author": {
+    "name": "Damon Oehlman",
+    "email": "damon.oehlman@gmail.com"
+  },
   "version": "0.1.6",
   "dependencies": {
     "clean-css": "^2",
     "stylus": "^0.47.3",
-    "through": "^2"
+    "through": "^2",
+    "glob": "~4.0.6",
+    "lodash": "~2.4.1"
   },
   "devDependencies": {
     "crel": "~1.1.0",
@@ -34,5 +39,13 @@
   "bugs": {
     "url": "https://github.com/DamonOehlman/stylify/issues"
   },
-  "homepage": "https://github.com/DamonOehlman/stylify"
+  "homepage": "https://github.com/DamonOehlman/stylify",
+  "readme": "# stylify\n\nbrowserify v2 plugin for [stylus](https://github.com/LearnBoost/stylus).\n\n\n[![NPM](https://nodei.co/npm/stylify.png)](https://nodei.co/npm/stylify/)\n\n[![unstable](https://img.shields.io/badge/stability-unstable-yellowgreen.svg)](https://github.com/badges/stability-badges) \n\n## Example Usage\n\nUsage is very simple when combined with the\n[insert-css](https://github.com/substack/insert-css) (or similar) module.\nConsider the following example, which dynamically creates a couple of\ndiv tags, and dynamically assigned styles:\n\n```js\nvar insertCss = require('insert-css');\nvar crel = require('crel');\n\n// create some dom elements to demo our styles\nvar elements = ['square', 'rect'].map(function(cls) {\n  return crel('div', { class: 'box ' + cls });\n}).forEach(document.body.appendChild.bind(document.body));\n\n// insert our stylus css into our app\ninsertCss(require('./simple.styl'));\n```\n\nYou can see the final statement uses a familar node `require` call to \nbring in a stylus stylesheet:\n\n```css\nsidelength = 40px\nboxborder = black\n\nbody\n  margin 0\n  padding 0\n\n.box\n  border: 1px solid boxborder\n  margin: 5px\n\n.square\n  width: sidelength\n  height: sidelength\n\n.rect\n  width: sidelength * 2\n  height: sidelength\n```\n\n## License(s)\n\n### MIT\n\nCopyright (c) 2014 Damon Oehlman <damon.oehlman@gmail.com>\n\nPermission is hereby granted, free of charge, to any person obtaining\na copy of this software and associated documentation files (the\n'Software'), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to\npermit persons to whom the Software is furnished to do so, subject to\nthe following conditions:\n\nThe above copyright notice and this permission notice shall be\nincluded in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,\nEXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.\nIN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,\nTORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE\nSOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\n",
+  "readmeFilename": "README.md",
+  "_id": "stylify@0.1.6",
+  "dist": {
+    "shasum": "ade65c6f3f7d89b702565f7b50dd9dee36f88862"
+  },
+  "_from": "stylify@",
+  "_resolved": "https://registry.npmjs.org/stylify/-/stylify-0.1.6.tgz"
 }


### PR DESCRIPTION
Whilst using stylify I noticed I was unable to use @require for mixins as the path hadn't been set when stylus is called. I've created the additional hooks need to pass along path information. This follows the browserify config convention of placing a config map in package.json. 
