### PR TITLE
Upgrade dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - stable
-  - iojs
+  - 6 # lts (boron)
+  - 7 # stable
 
 notifications:
   email:

--- a/index.js
+++ b/index.js
@@ -7,8 +7,7 @@ var stylus = require('stylus'),
   resolve = require('resolve'),
   flatten = require('lodash.flatten'),
   uniq = require('lodash.uniq'),
-  merge = require('lodash.merge'),
-  isArray = require('lodash.isarray');
+  merge = require('lodash.merge');
 
 var defaultOptions = {
   set: {
@@ -50,14 +49,14 @@ function getPackageOptions() {
 }
 
 function parsePaths(paths) {
-  paths = isArray(paths) ? paths : [];
+  paths = Array.isArray(paths) ? paths : [];
   return uniq(flatten(paths.map(function(path) {
     return glob.sync(path);
   })));
 }
 
 function resolveUses(uses) {
-  if (!isArray(uses)) {
+  if (!Array.isArray(uses)) {
     uses = [uses];
   }
 
@@ -75,7 +74,7 @@ function applyOptions(stylus, options) {
   ['set', 'include', 'import', 'define', 'use'].forEach(function(method) {
     var option = options[method];
 
-    if (isArray(option)) {
+    if (Array.isArray(option)) {
       for (var i = 0; i < option.length; i++)
         stylus[method](option[i]);
     } else {

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "through2": "^2.0.0"
   },
   "devDependencies": {
-    "autoprefixer": "^5.2.0",
+    "autoprefixer": "^6.7.4",
     "concat-stream": "^1.4.7",
-    "crel": "^2.1.8",
-    "insert-css": "^0.2.0",
+    "crel": "^3.0.0",
+    "insert-css": "^2.0.0",
     "nib": "1.1.2",
     "tap": "^10.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "browserify plugin for stylus",
   "version": "1.3.1",
   "dependencies": {
-    "glob": "^5.0.14",
+    "glob": "^7.1.1",
     "lodash.flatten": "^4.4.0",
     "lodash.merge": "^4.6.0",
     "lodash.uniq": "^4.5.0",
@@ -17,7 +17,7 @@
     "crel": "^2.1.8",
     "insert-css": "^0.2.0",
     "nib": "1.1.2",
-    "tap": "^1.3.2"
+    "tap": "^10.2.0"
   },
   "scripts": {
     "start": "beefy examples/simple.js -- -t ./",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,10 @@
   "dependencies": {
     "glob": "^5.0.14",
     "lodash.flatten": "^4.4.0",
-    "lodash.isarray": "^4.0.0",
     "lodash.merge": "^4.6.0",
     "lodash.uniq": "^4.5.0",
     "resolve": "^1.1.5",
-    "stylus": "^0.52.0",
+    "stylus": "0.54.5",
     "through2": "^2.0.0"
   },
   "devDependencies": {
@@ -17,7 +16,7 @@
     "concat-stream": "^1.4.7",
     "crel": "^2.1.8",
     "insert-css": "^0.2.0",
-    "nib": "^1.1.0",
+    "nib": "1.1.2",
     "tap": "^1.3.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "version": "1.3.1",
   "dependencies": {
     "glob": "^5.0.14",
-    "lodash.flatten": "^3.0.0",
-    "lodash.isarray": "^3.0.0",
-    "lodash.merge": "^3.0.2",
-    "lodash.uniq": "^3.0.1",
+    "lodash.flatten": "^4.4.0",
+    "lodash.isarray": "^4.0.0",
+    "lodash.merge": "^4.6.0",
+    "lodash.uniq": "^4.5.0",
     "resolve": "^1.1.5",
     "stylus": "^0.52.0",
     "through2": "^2.0.0"


### PR DESCRIPTION
- Upgrade dependencies
  - resolves the usage of `minimatch@2` which has the RegExp issue (triggers a warning in bithound)

- Removed `lodash.isarray` \o/
